### PR TITLE
Avoid using the proprietary extension in the test

### DIFF
--- a/test/posixregexp_test.rb
+++ b/test/posixregexp_test.rb
@@ -129,11 +129,7 @@ assert('PosixMatchData#values_at') do
 end
 
 assert('String#scan') do
-  if /Darwin/ =~ `uname`
-    assert_equal ["abcd", "efgh", "ijkl"], "abcdefghijklmn".scan(/..../)
-  else
-    assert_equal ["abcd", "efgh", "ijkl"], "abcdefghijklmn".scan(/\w\w\w\w/)
-  end
+  assert_equal ["abcd", "efgh", "ijkl"], "abcdefghijklmn".scan(/..../)
 
   assert_equal [["b", "cd"], ["f", "gh"], ["j", "kl"]],
   "abcdefghijklmn".scan(/.(.)(..)/)


### PR DESCRIPTION
For example, on FreeBSD, the test fails because `uname` does not contain "Darwin" and does not support the metacharacter `\w` that deviates from POSIX.

----

かわりに POSIX regex は `[[:alnum:]]` のようなメタ文字が定義されており、FreeBSD はこっちの対応はあります。
