### PR TITLE
Support `MRB_UTF8_STRING` configuration

### DIFF
--- a/build_config/local.rb
+++ b/build_config/local.rb
@@ -13,3 +13,16 @@ MRuby::Build.new do |conf|
     # conf.gem core: 'mruby-bin-debugger'
   #end
 end
+
+MRuby::Build.new('utf8') do |conf|
+  toolchain :gcc
+  conf.compilers.each { |cc| cc.defines << 'MRB_UTF8_STRING' }
+  conf.gem core: 'mruby-bin-mruby'
+  conf.gem core: 'mruby-print'
+  conf.gem core: 'mruby-sprintf'
+  conf.gem File.expand_path('../../', __FILE__)
+  conf.gem core: 'mruby-bin-mrbc' if MRuby::Source::MRUBY_RELEASE_NO <= 30000
+
+  conf.enable_test
+  conf.enable_debug
+end

--- a/mrblib/string_ext.rb
+++ b/mrblib/string_ext.rb
@@ -53,7 +53,7 @@ class String
         break if m.begin(0) - index < 0
         index += len
       end
-      str += self.byteslice(index..-1) if index < self.bytesize
+      str += self[index..-1] if index < self.length
       str
     else
       orig_gsub(*args, &block)

--- a/test/posixregexp_test.rb
+++ b/test/posixregexp_test.rb
@@ -161,3 +161,28 @@ assert('String#sub') do
   assert_equal "@-abackbacbab", "acbabackbacbab".sub(/a.?b/, "@-")
   assert_equal "@-acbcbabackbacbab", "acbabackbacbab".sub(/a(.?b)/, '@-\0\1')
 end
+
+# See the commit message below for the reason why the emoji is used to determine UTF-8.
+# However, it would be better to rewrite it in the future.
+# https://github.com/mruby/mruby/commit/906f9f2ba752c53162bf4bab6264b78a38f05fd8
+if "💫".size == 1
+  assert('PosixRegexp#match (with UTF-8)') do
+    assert_not_nil /５/.match("１２３４５６７８９", 4)
+    assert_nil /５/.match("１２３４５６７８９", 5)
+    assert_nil /５/.match("１２３４５６７８９", -4)
+  end
+
+  assert('PosixMatchData#begin') do
+    m = /((ａ)?(ｚ)?ｘ)?/.match("ｚｘ")
+    assert_equal 0, m.begin(3)
+  end
+
+  assert('PosixMatchData#end') do
+    m = /((ａ)?(ｚ)?ｘ)?/.match("ｚｘ")
+    assert_equal 1, m.end(3)
+  end
+
+  assert('String#gsub (with UTF-8)') do
+    assert_equal "１２３４５６７８９✔", "１２３４５６７８９✘".gsub(/✘/, "✔")
+  end
+end


### PR DESCRIPTION
_The commit message has been rewritten to fix the problem in the previous PR._

The C space is mainly handled in "byte units", and when transferring to/from the Ruby space, "byte units" and "character units" are converted.
On the Ruby space, "character unit" is handled.
