### PR TITLE
`MatchData#{begin,end}` method raises exception on out-of-index

### DIFF
--- a/src/posix-regexp.c
+++ b/src/posix-regexp.c
@@ -89,6 +89,16 @@ str_index_byte2char(mrb_state *mrb, const char *str, mrb_int len, mrb_int nbytes
 }
 #endif /* MRB_UTF8_STRING */
 
+static mrb_int
+matchdata_check_index(mrb_state *mrb, mrb_int pos, mrb_int max)
+{
+  if (pos < 0 || pos >= max) {
+    mrb_raise(mrb, E_INDEX_ERROR, "index out of matches");
+  }
+
+  return pos;
+}
+
 static const char match_gv_names[][3] =
   {
    "$1",
@@ -293,9 +303,7 @@ static mrb_value mrb_posixmatchdata_begin(mrb_state *mrb, mrb_value self)
 
   mrb_int pos;
   mrb_get_args(mrb, "i", &pos);
-
-  if(pos >= data->len)
-    return mrb_nil_value();
+  pos = matchdata_check_index(mrb, pos, data->len);
 
   int d = data->matches[pos].rm_so;
   if (d == -1)
@@ -314,9 +322,7 @@ static mrb_value mrb_posixmatchdata_end(mrb_state *mrb, mrb_value self)
 
   mrb_int pos;
   mrb_get_args(mrb, "i", &pos);
-
-  if(pos > data->len)
-    return mrb_nil_value();
+  pos = matchdata_check_index(mrb, pos, data->len);
 
   int d = data->matches[pos].rm_eo;
   if (d == -1)

--- a/test/posixregexp_test.rb
+++ b/test/posixregexp_test.rb
@@ -74,6 +74,8 @@ assert('PosixMatchData#begin') do
   assert_equal 0, m.begin(1)
   assert_equal nil, m.begin(2)
   assert_equal 0, m.begin(3)
+  assert_raise(IndexError) { m.begin(4) }
+  assert_raise(IndexError) { m.begin(-1) }
 end
 
 assert('PosixMatchData#end') do
@@ -82,6 +84,8 @@ assert('PosixMatchData#end') do
   assert_equal 2, m.end(1)
   assert_equal nil, m.end(2)
   assert_equal 1, m.end(3)
+  assert_raise(IndexError) { m.end(4) }
+  assert_raise(IndexError) { m.end(-1) }
 end
 
 assert('PosixMatchData#post_match') do


### PR DESCRIPTION
The purpose is to improve compatibility with CRuby.
Also, previously it could cause `SIGSEGV` if a negative number was given, but this will be fixed at the same time.