### PR TITLE
Automatically calculate length instead of using "sentinel"

### DIFF
--- a/src/posix-regexp.c
+++ b/src/posix-regexp.c
@@ -51,8 +51,9 @@ static const char match_gv_names[][3] =
    "$7",
    "$8",
    "$9",
-   {0}
   };
+
+#define match_gv_names_len (sizeof(match_gv_names) / sizeof(match_gv_names[0]))
 
 static void mrb_regfree(mrb_state *mrb, void *p) {
   if (p != NULL) {
@@ -154,7 +155,7 @@ static mrb_value mrb_posixregexp_match(mrb_state *mrb, mrb_value self)
 
   if (pos < 0) {
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$matchdata"), mrb_nil_value());
-    for (int i = 0; !match_gv_names[i]; i++) {
+    for (int i = 0; i < match_gv_names_len; i++) {
       mrb_gv_set(mrb, mrb_intern_cstr(mrb, match_gv_names[i]), mrb_nil_value());
     }
     return mrb_nil_value();
@@ -172,7 +173,7 @@ static mrb_value mrb_posixregexp_match(mrb_state *mrb, mrb_value self)
     break;
   case REG_NOMATCH:
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$matchdata"), mrb_ary_new(mrb));
-    for (int i = 0; !match_gv_names[i]; i++) {
+    for (int i = 0; i < match_gv_names_len; i++) {
       mrb_gv_set(mrb, mrb_intern_cstr(mrb, match_gv_names[i]), mrb_ary_new(mrb));
     }
 
@@ -197,7 +198,7 @@ static mrb_value mrb_posixregexp_match(mrb_state *mrb, mrb_value self)
   mrb_iv_set(mrb, matched, mrb_intern_lit(mrb, "@length"), mrb_fixnum_value(nmatch));
 
   mrb_gv_set(mrb, mrb_intern_lit(mrb, "$matchdata"), matched);
-  for (int i = 0; (i < nmatch - 1 && match_gv_names[i]) ; i++) {
+  for (int i = 0; (i < nmatch - 1 && i < match_gv_names_len) ; i++) {
     mrb_gv_set(mrb, mrb_intern_cstr(mrb, match_gv_names[i]),
                mrb_funcall(mrb, matched, "[]", 1, mrb_fixnum_value(i + 1)));
   }


### PR DESCRIPTION
Here is one of the warnings reported by `gcc12 -Waddress`:

```
mruby-posix-regexp/src/posix-regexp.c: In function 'mrb_posixregexp_match':
mruby-posix-regexp/src/posix-regexp.c:208:21: warning: the comparison will always evaluate as 'true' for the address of 'match_gv_names' will never be NULL [-Waddress]
  208 |     for (int i = 0; !match_gv_names[i]; i++) {
      |                     ^
```

`match_gv_names[i]` is a pointer to a string and must be exactly one of the following as a sentinel:

  - Replace with `match_gv_names[i][0]`
  - Use `NULL` instead of `{0}` as the sentinel of `match_gv_names`

However, this patch chooses a way to reduce `sizeof(match_gv_names)` (4 or 8 bytes) and also reduce instruction sequence (a some bytes).

---

おそらく警告された部分は `match_gv_names[9]` である番兵 (`{0}`) の次となる `match_gv_names[10]` を参照しています。
